### PR TITLE
gff3toembl on Mac OS X

### DIFF
--- a/gff3toembl/EMBLContig.py
+++ b/gff3toembl/EMBLContig.py
@@ -58,7 +58,7 @@ class EMBLContig(object):
       elif feature_1.start > feature_2.start:
         return 1
       else:
-        return feature_2.end - feature_1.end
+        return int(feature_2.end - feature_1.end)
     return sorted(self.features.values(), cmp=compare_features)
 
 class EMBLFeature(object):

--- a/gff3toembl/EMBLWriter.py
+++ b/gff3toembl/EMBLWriter.py
@@ -71,7 +71,7 @@ class EMBLWriter(object):
 
     def sort_and_tidy_gff_file(self):
         try:
-          subprocess.check_call("gt gff3 -sort -retainids -tidy -o "+str(self.fixed_gff_file)+" "+str(self.gff3_file), shell=True)
+          subprocess.check_call("gt gff3 -force -sort -retainids -tidy -o "+str(self.fixed_gff_file)+" "+str(self.gff3_file), shell=True)
         except:
           sys.exit("Failed to sort and tidy gff file with GT")
 


### PR DESCRIPTION
I just tested gff3toembl on my Mac and it works well with the fixes in this PR, provided that you install GenomeTools 1.5.4 or later (which fixed the Python bindings) and have the path to `libgenometools.dylib` in your `$DYLD_LIBRARY_PATH` (not `$LD_LIBRARY_PATH` as in Linux).

I also add a small fix allowing multiple runs on the same input file.