### PR TITLE
Use Python 3 ready exception, print, etc

### DIFF
--- a/gff3toembl/EMBLContig.py
+++ b/gff3toembl/EMBLContig.py
@@ -202,7 +202,7 @@ class EMBLFeature(object):
     attribute_values = map(strip_quotes, attribute_values)
     attribute_values = filter(remove_hypotheticals, attribute_values)
     attribute_values = map(replace_unknown_with_uncharacterised, attribute_values)
-    attribute_values = filter(remove_empty_strings, attribute_values)
+    attribute_values = list(filter(remove_empty_strings, attribute_values))
     chosen_value = attribute_values[0] if len(attribute_values) > 0 else 'Uncharacterised protein'
     return [('product', chosen_value)]
 

--- a/gff3toembl/EMBLContig.py
+++ b/gff3toembl/EMBLContig.py
@@ -52,14 +52,9 @@ class EMBLContig(object):
 
   def sorted_features(self):
     # Features should be sorted by start and then by end irrespective of strand
-    def compare_features(feature_1, feature_2):
-      if feature_1.start < feature_2.start:
-        return -1
-      elif feature_1.start > feature_2.start:
-        return 1
-      else:
-        return int(feature_2.end - feature_1.end)
-    return sorted(self.features.values(), cmp=compare_features)
+    def sort_key(feature):
+      return (feature.start, feature.end)
+    return sorted(self.features.values(), key=sort_key)
 
 class EMBLFeature(object):
   inference_to_db_xref_map = {

--- a/gff3toembl/EMBLWriter.py
+++ b/gff3toembl/EMBLWriter.py
@@ -90,8 +90,8 @@ class EMBLWriter(object):
         try:
             while (vs.next_tree()):
                 pass
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             exit(1)
         self.create_output_file(self.organism, self.taxonid, self.project, self.authors, self.title, self.publication, self.genome_type, self.classification)
         self.create_chromosome_list(self.chromosome_list, self.output_filename)


### PR DESCRIPTION
Some of these changes like the exception change break on Python 2.5 or older.

The changes should all work on Python 2.6, 2.7 and 3.

This does not address a number of other problems with the current code under Python 3.