### PR TITLE
EMBL files wrap at 80 characters, not 79

### DIFF
--- a/gff3toembl/EMBLContig.py
+++ b/gff3toembl/EMBLContig.py
@@ -153,7 +153,7 @@ class EMBLFeature(object):
     wrapper = TextWrapper()
     wrapper.initial_indent='FT                   '
     wrapper.subsequent_indent='FT                   '
-    wrapper.width=79
+    wrapper.width=80  # can use 80 characters plus the new line
     attribute_text_template='/{attribute_key}={attribute_value}'
     attribute_text=attribute_text_template.format(attribute_key=key, attribute_value=value)
     return wrapper.fill(attribute_text)
@@ -163,7 +163,7 @@ class EMBLFeature(object):
     wrapper = TextWrapper()
     wrapper.initial_indent='FT                   '
     wrapper.subsequent_indent='FT                   '
-    wrapper.width=79
+    wrapper.width=80  # can use 80 characters plus the new line
     wrapper.break_on_hyphens=True
     attribute_text_template='/{attribute_key}="{attribute_value}"'
     attribute_text=attribute_text_template.format(attribute_key=key, attribute_value=value)
@@ -173,7 +173,7 @@ class EMBLFeature(object):
     wrapper = TextWrapper()
     wrapper.initial_indent='FT                   '
     wrapper.subsequent_indent='FT                   '
-    wrapper.width=79
+    wrapper.width=80  # can use 80 characters plus the new line
     attribute_text_template='/{attribute_key}="{attribute_value}"'
     attribute_text=attribute_text_template.format(attribute_key=key, attribute_value=value)
     return wrapper.fill(attribute_text)
@@ -359,7 +359,7 @@ FH
     wrapper = TextWrapper()
     wrapper.initial_indent=key + '   '
     wrapper.subsequent_indent=key + '   '
-    wrapper.width=79
+    wrapper.width=80  # can use 80 characters plus the new line
     attribute_text_template='{attribute_quote_character}{attribute_header_text}{attribute_quote_character}{attribute_final_character}'
     attribute_text=attribute_text_template.format(attribute_header_text = header_text, 
                                                   attribute_quote_character = quote_character, 

--- a/gff3toembl/tests/EMBLContig_test.py
+++ b/gff3toembl/tests/EMBLContig_test.py
@@ -337,8 +337,8 @@ XX
 FH   Key             Location/Qualifiers
 FH
 FT   source          1..1234
-FT                   /organism="reeeeeeeeeeeeeeaaaaaaaaaaaaaallllllllllyyyyyyyy
-FT                   yyyyyyyyyyyy_long_name"
+FT                   /organism="reeeeeeeeeeeeeeaaaaaaaaaaaaaallllllllllyyyyyyyyy
+FT                   yyyyyyyyyyy_long_name"
 FT                   /mol_type="genomic DNA"
 FT                   /db_xref="taxon:5678"
 FT                   /note="chromX"

--- a/gff3toembl/tests/data/expected_large_annotation.embl
+++ b/gff3toembl/tests/data/expected_large_annotation.embl
@@ -328,8 +328,8 @@ FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /locus_tag="8233_4#93_02157"
 FT                   /transl_table=11
 FT   CDS             complement(31340..32062)
-FT                   /product="CobB/CobQ-like glutamine amidotransferase
-FT                   domain-containing protein"
+FT                   /product="CobB/CobQ-like glutamine amidotransferase domain-
+FT                   containing protein"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_006195962.1"
 FT                   /db_xref="CDD:PRK00784"
@@ -1110,8 +1110,8 @@ FT                   /locus_tag="8233_4#93_02245"
 FT                   /gene="ssb_2"
 FT                   /transl_table=11
 FT   CDS             complement(112145..112630)
-FT                   /product="Metallo-beta-lactamase superfamily domain
-FT                   protein in prophage"
+FT                   /product="Metallo-beta-lactamase superfamily domain protein
+FT                   in prophage"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005742694.1"
 FT                   /locus_tag="8233_4#93_02246"
@@ -1546,8 +1546,7 @@ FT                   /locus_tag="8233_4#93_02294"
 FT                   /gene="gcp"
 FT                   /transl_table=11
 FT   CDS             complement(157577..158041)
-FT                   /product="Ribosomal-protein-S18p-alanine
-FT                   acetyltransferase"
+FT                   /product="Ribosomal-protein-S18p-alanine acetyltransferase"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005742740.1"
 FT                   /db_xref="CDD:PRK09491"
@@ -4976,8 +4975,8 @@ FT                   /EC_number="4.4.1.21"
 FT                   /gene="luxS"
 FT                   /transl_table=11
 FT   CDS             37042..38226
-FT                   /product="HmrA protein involved in methicillin resistance
-FT                   / amidohydrolase of M40 family"
+FT                   /product="HmrA protein involved in methicillin resistance /
+FT                   amidohydrolase of M40 family"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005742822.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:P76052"
@@ -5601,8 +5600,7 @@ FT                   /EC_number="3.6.3.12"
 FT                   /locus_tag="8233_4#93_02403"
 FT                   /transl_table=11
 FT   CDS             92753..94780
-FT                   /product="putative potassium-transporting ATPase subunit
-FT                   B"
+FT                   /product="putative potassium-transporting ATPase subunit B"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005326403.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:P03960"
@@ -7805,8 +7803,7 @@ FT                   /EC_number="4.2.1.2"
 FT                   /gene="citG"
 FT                   /transl_table=11
 FT   CDS             complement(11687..12508)
-FT                   /product="ribosomal large subunit pseudouridine synthase
-FT                   D"
+FT                   /product="ribosomal large subunit pseudouridine synthase D"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005742555.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:P33643"
@@ -9138,8 +9135,8 @@ FT                   /EC_number="3.2.1.93"
 FT                   /gene="treA"
 FT                   /transl_table=11
 FT   CDS             complement(7204..8631)
-FT                   /product="PTS system trehalose-specific transporter
-FT                   subunit IIBC"
+FT                   /product="PTS system trehalose-specific transporter subunit
+FT                   IIBC"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_006194612.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:P36672"
@@ -10449,8 +10446,7 @@ FT                   /locus_tag="8233_4#93_02554"
 FT                   /gene="yaaT"
 FT                   /transl_table=11
 FT   CDS             5006..5353
-FT                   /product="DNA replication intitiation control protein
-FT                   YabA"
+FT                   /product="DNA replication intitiation control protein YabA"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005741210.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:Q99WB7"
@@ -10704,8 +10700,8 @@ FT                   /db_xref="PFAM:PF04977.9"
 FT                   /locus_tag="8233_4#93_02576"
 FT                   /transl_table=11
 FT   CDS             26912..27313
-FT                   /product="RNA binding protein, contains ribosomal
-FT                   protein S1 domain"
+FT                   /product="RNA binding protein, contains ribosomal protein
+FT                   S1 domain"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005741232.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:P80870"
@@ -12314,8 +12310,7 @@ FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /locus_tag="8233_4#93_02632"
 FT                   /transl_table=11
 FT   CDS             complement(316..618)
-FT                   /product="putative bacteriocin transport accessory
-FT                   protein"
+FT                   /product="putative bacteriocin transport accessory protein"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /db_xref="TIGRFAM:TIGR01295"
 FT                   /locus_tag="8233_4#93_02633"

--- a/gff3toembl/tests/data/expected_large_annotation.embl
+++ b/gff3toembl/tests/data/expected_large_annotation.embl
@@ -81,8 +81,7 @@ FT                   /db_xref="PFAM:PF06081.5"
 FT                   /locus_tag="8233_4#93_02132"
 FT                   /transl_table=11
 FT   CDS             complement(7640..9376)
-FT                   /product="Lipid A export ATP-binding/permease protein
-FT                   MsbA"
+FT                   /product="Lipid A export ATP-binding/permease protein MsbA"
 FT                   /inference="ab initio prediction:Prodigal:2.60"
 FT                   /inference="similar to AA sequence:RefSeq:YP_005742571.1"
 FT                   /db_xref="UniProtKB/Swiss-Prot:Q99T13"


### PR DESCRIPTION
Currently ``gff3_to_embl`` produces EMBL files where the header and FT annotation lines are wrapped at 79 characters (plus the new line). They could include one more character.

The EMBL specification on the FT lines says:
ftp://ftp.ebi.ac.uk/pub/databases/embl/doc/usrman.txt

```
3.4.16 The FT Line
The FT (Feature Table) lines provide a mechanism for the annotation of the
sequence data. Regions or sites in the sequence which are of interest are
listed in the table. In general, the features in the feature table represent
signals or other characteristics reported in the cited references. In some
cases, ambiguities or features noted in the course of data preparation have 
been included.  The feature table is subject to expansion or change as more
becomes known about a given sequence.
Feature Table Definition Document:
A complete and definitive description of the feature table is given 
in the document "The DDBJ/ENA/GenBank Feature Table:  Definition". 
URL: ftp://ftp.ebi.ac.uk/pub/databases/embl/doc/FT_current.txt
Much effort is expended in the design of the feature table to try to
ensure that it will be self-explanatory to the human reader, and we therefore
expect that the official definition document will be of interest mainly
to software developers rather than to end-users of the database.
A browser derived from the document is provided to assist users in navigating
and composing feature table representations at
http://www.ebi.ac.uk/ena/WebFeat/.
```

In turn, the DDBJ/ENA/GenBank Feature Table says:
ftp://ftp.ebi.ac.uk/pub/databases/embl/doc/FT_current.txt

```
4.1 Format examples


Feature table format example (EMBL): 
FT   source          1..1859
FT                   /db_xref="taxon:3899"
FT                   /organism="Trifolium repens"
FT                   /tissue_type="leaves"
FT                   /clone_lib="lambda gt10"
FT                   /clone="TRE361"
FT                   /mol_type="genomic DNA"
FT   CDS             14..1495
FT                   /db_xref="MENDEL:11000"
FT                   /db_xref="UniProtKB/Swiss-Prot:P26204"
FT                   /note="non-cyanogenic"
FT                   /EC_number="3.2.1.21"
FT                   /product="beta-glucosidase"
FT                   /protein_id="CAA40058.1"
FT                   /translation="MDFIVAIFALFVISSFTITSTNAVEASTLLDIGNLSR.......
---------+---------+---------+---------+---------+---------+---------+---------
1       10        20        30        40        50        60        70       79

Feature table format example (GenBank):

     source          1..8959
                     /organism="Homo sapiens"
                     /db_xref="taxon:9606"
                     /mol_type="genomic DNA"
     gene            212..8668
                     /gene="NF1"
     CDS             212..8668
                     /gene="NF1"
                     /note="putative"
                     /codon_start=1
                     /product="GAP-related protein"
                     /protein_id="AAA59924.1"
                     /translation="MAAHRPVEWVQAVVSRFDEQLPIKTGQQNTHTKVSTE.......
---------+---------+---------+---------+---------+---------+---------+---------
1       10        20        30        40        50        60        70       79

Feature table format example (DDBJ):

 
     source          1..2136
                     /clone="pK28"
                     /organism="Rattus norvegicus"
                     /strain="Sprague-Dawley"
                     /tissue_type="kidney"
                     /mol_type="genomic DNA" 
     mRNA            19..2128
     CDS             31..1212
                     /codon_start=1
                     /function="Dual specificity protein tyrosine/threonine
                     kinase"
                     /product="MAP kinase kinase"
                     /protein_id="BAA02603.1"
                     /translation="MPKKKPTPIQLNPAPDGSAVNGTSSAETNLEALQKKL.......
---------+---------+---------+---------+---------+---------+---------+---------
1       10        20        30        40        50        60        70       79
```

i.e. Examples using 79 characters plus the new line.

However, it later says explicitly up to 80 characters can be used (not counting the new line).

```
4.3 Data item positions


The position of the data items within the feature descriptor line is as follows: 
     column position    data item
     ---------------    ---------

     1-5                blank 
     6-20               feature key
     21                 blank
     22-80              location

Data on the qualifier and continuation lines begins in column position 22 (the 
first 21 columns contain blanks). The EMBL format for all lines differs from 
the GenBank / DDBJ formats  that it includes a line type abbreviation in 
columns 1 and 2. 
```

The 80 character limit (plus new line) appears to be what EMBL files actually use, e.g. from http://www.ebi.ac.uk/ena/data/view/HE601624&display=text we observe:

```
FT                   /translation="AIQRNDIVALNNQFLCNFGFTIDWEQIFEDNRKQMFIPDRKEKTV
FT                   SHAGCDIALRKYTDGR"
FT   gap             19826..20025
FT                   /estimated_length=200
FT   CDS             join(51849..51861,51901..51987,52024..52416,52448..52679,
FT                   52715..52802,52842..52947,52982..53133,54024..54414,
FT                   56607..56698,58714..58797,60654..60877,61856..61986,
FT                   63528..63888,64396..64595,68110..68179,69917..70203,
FT                   71768..71956,75110..75302,81605..81860,83832..83905,
FT                   86063..86235,87707..87928,102929..103281,105637..105881,
FT                   107417..107711,110058..110198,112709..112855,
FT                   114774..114890)
FT                   /locus_tag="Smp_160500"
FT                   /product="nalp (nacht, leucine rich repeat and pyrin domain
FT                   containing)-related"
FT                   /db_xref="EnsemblGenomes-Gn:Smp_160500"
FT                   /db_xref="EnsemblGenomes-Tr:Smp_160500.1"
FT                   /db_xref="InterPro:IPR001611"
FT                   /db_xref="InterPro:IPR002110"
FT                   /db_xref="InterPro:IPR011990"
FT                   /db_xref="InterPro:IPR019734"
FT                   /db_xref="InterPro:IPR020683"
FT                   /db_xref="InterPro:IPR032675"
FT                   /db_xref="UniProtKB/TrEMBL:G4V599"
FT                   /protein_id="CCD74584.1"
FT                   /translation="MNVRKLIEQRAKTKVTKEKAELTLTIAAIYSEQGSHDSALVEYKK
FT                   YLEVWESKEDNLQCAVANRYLAECYIEMCDFTQAIFHTNRYLQLSLLVGNKIEQQRAYV
```

This shows both the translation lines and a product line using the full 80 characters (plus new line).

Sadly I could not find anything explicit in the specification about header line lengths, but found examples wrapping using the full 80 characters (plus new line), e.g.
http://www.ebi.ac.uk/ena/data/view/HE601623&display=text

```
OS   Homo sapiens (human)
OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
OC   Homo.
```

and:
http://www.ebi.ac.uk/ena/data/view/HE601611&display=text

```
RL   Submitted (30-SEP-2011) to the INSDC.
RL   Fan C., College of Environmental Science and Engineering, Hunan University,
RL   Changsha, Hunan 410082, P.R. CHINA.
```

Note the  ``gff3_to_embl`` output does not report the translation (as recommended for ENA submission), so this is only really noticeable on a subset of the annotation lines.

This patch seems to be a big step in the right direction, although I suspect there are a few corner cases where the full 80 characters are not being used.