### PR TITLE
More wrapping tests; Fix ignored test

### DIFF
--- a/gff3toembl/tests/EMBLContig_test.py
+++ b/gff3toembl/tests/EMBLContig_test.py
@@ -3,19 +3,6 @@ from mock import MagicMock, patch
 from gff3toembl.EMBLContig import EMBLContig, EMBLHeader, EMBLFeature, EMBLSequence
 
 
-class TestEMBLFeature(unittest.TestCase):
-    
-  def test_split_product_attribute_on_hyphen(self):
-    source_attributes = {"organism": 'abc', "db_xref": "taxon:5678", "note": "chromX"}
-    feature = EMBLFeature('source', 1, 1234, '+', source_attributes)
-    
-    formatted_product = feature.product_attribute_formatter('product','2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthase')
-    expected_product = """\
-FT                   /product="2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carbox
-FT                   ylate synthase"
-"""
-    self.assertEqual(formatted_product, expected_product)
-
 class TestEMBLContig(unittest.TestCase):
 
   def create_blank_bit_of_contig(self):
@@ -868,6 +855,15 @@ FT                   hij klm nop qrs tuvw xyz"\
     formatted_product = feature.product_attribute_formatter('product','Permease for cytosine/purines, uracil, thiamine, allantoin')
     expected_product = 'FT                   /product="Permease for cytosine/purines, uracil, thiamine,\n' + \
                        'FT                   allantoin"'
+
+  def test_split_product_attribute_on_hyphen(self):
+    source_attributes = {"organism": 'abc', "db_xref": "taxon:5678", "note": "chromX"}
+    feature = EMBLFeature('source', 1, 1234, '+', source_attributes)
+    # TODO: This test currently 'passes' but shows the undesirable
+    # behaviour of splitting up a long word.
+    formatted_product = feature.product_attribute_formatter('product','2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthase')
+    expected_product = 'FT                   /product="2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxy\n' + \
+                       'FT                   late synthase"'
     self.assertEqual(formatted_product, expected_product)
 
 

--- a/gff3toembl/tests/EMBLContig_test.py
+++ b/gff3toembl/tests/EMBLContig_test.py
@@ -843,6 +843,34 @@ FT                   hij klm nop qrs tuvw xyz"\
     expected_coordinates = '1..10'
     self.assertEqual(calculated_coordinates, expected_coordinates)
 
+  def test_no_wrap_at_length_79(self):
+    source_attributes = {"organism": 'abc', "db_xref": "taxon:5678", "note": "chromX"}
+    feature = EMBLFeature('source', 1, 1234, '+', source_attributes)
+
+    formatted_product = feature.product_attribute_formatter('product','Anthranilate 1,2-dioxygenase ferredoxin subunit')
+    expected_product = 'FT                   /product="Anthranilate 1,2-dioxygenase ferredoxin subunit"'
+    assert len(expected_product) == 79
+    self.assertEqual(formatted_product, expected_product)
+
+  def test_no_wrap_at_length_80(self):
+    source_attributes = {"organism": 'abc', "db_xref": "taxon:5678", "note": "chromX"}
+    feature = EMBLFeature('source', 1, 1234, '+', source_attributes)
+
+    formatted_product = feature.product_attribute_formatter('product','1,4-dihydroxy-2-naphthoate octaprenyltransferase')
+    expected_product = 'FT                   /product="1,4-dihydroxy-2-naphthoate octaprenyltransferase"'
+    assert len(expected_product) == 80
+    self.assertEqual(formatted_product, expected_product)
+
+  def test_wrap_with_space_at_80(self):
+    source_attributes = {"organism": 'abc', "db_xref": "taxon:5678", "note": "chromX"}
+    feature = EMBLFeature('source', 1, 1234, '+', source_attributes)
+
+    formatted_product = feature.product_attribute_formatter('product','Permease for cytosine/purines, uracil, thiamine, allantoin')
+    expected_product = 'FT                   /product="Permease for cytosine/purines, uracil, thiamine,\n' + \
+                       'FT                   allantoin"'
+    self.assertEqual(formatted_product, expected_product)
+
+
 class TestEMBLSequence(unittest.TestCase):
 
   def create_uninitialized_sequence(self):


### PR DESCRIPTION
Due to clashing class names, the test added in https://github.com/sanger-pathogens/gff3toembl/commit/37ed4f57b1bbda9bb5fec718c2b810d51f493898 was never live. This pull request activates the test with minor updates (now wrap at 80 chars, and no trailing new line).

However, the test was intended to verify #51 had been fixed - and instead shows that line-breaks are being inserted within long words.

In my pull request #53 I suggested this:

```
    wrapper.break_long_words=False
```

That alone stopped the line breaks within long words, but gave overly long lines.

I've tried the combination but this does not seem to work either...

```
    wrapper.break_long_words=False
    wrapper.break_on_hyphens=True
```

This pull request therefore just tests the current less-than-ideal behaviour, without fixing #51.