### PR TITLE
using six for urllib.parse for support of python 3

### DIFF
--- a/gff3toembl/EMBLContig.py
+++ b/gff3toembl/EMBLContig.py
@@ -1,6 +1,6 @@
 import re
 from textwrap import TextWrapper
-from urllib import unquote as gff3_unescape
+from six.moves.urllib.parse import unquote as gff3_unescape
 
 class EMBLContig(object):
   def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     url='https://github.com/sanger-pathogens/gff3toembl',
     scripts=glob.glob('scripts/*'),
     test_suite='nose.collector',
+    install_requires=['six'],
     tests_require=['nose >= 1.3', 'mock'],
     license='GPLv3',
     classifiers=[


### PR DESCRIPTION
Hello, this is just a small fix for using six to cope with the different version of python. It should run on python 3 now, and gff3toembl should appear soon in the bioconda repo also. 

Cheers,